### PR TITLE
Fix ecom data length bug and implement filter option for ecom adapter

### DIFF
--- a/can/__init__.py
+++ b/can/__init__.py
@@ -8,7 +8,7 @@ messages on a can bus.
 import logging
 from typing import Dict, Any
 
-__version__ = "4.0.0-dev.12"
+__version__ = "4.0.0-dev.13"
 
 log = logging.getLogger("can")
 

--- a/can/interfaces/ecom/canlib.py
+++ b/can/interfaces/ecom/canlib.py
@@ -258,6 +258,15 @@ class EcomBus(BusABC):
         if self._receive_own_messages:
             options |= 1 << 4
         # TODO : account for dlc
+
+        # If the length of the message is not 8 bytes, append 0x00s until length is 8
+        # Ultimately, any appended bytes beyond specified dlc will not be transmitted
+        # anyway
+        if len(msg.data) < 8:
+            append_bytes = 8-len(msg.data)
+            for i in range(0, append_bytes):
+                msg.data.append(0x00)
+
         data = (ctypes.c_byte * len(msg.data)).from_buffer(msg.data)
 
         # Begin tryign to transmit with consideration for the timeout.

--- a/can/interfaces/ecom/structures.py
+++ b/can/interfaces/ecom/structures.py
@@ -11,8 +11,8 @@ DEV_SEARCH_HANDLE = HANDLE
 class FFMessage(ctypes.Union):
     class SFFMessage(ctypes.Structure):
         _fields_ = [
-            ("IDH", ctypes.c_byte),
-            ("IDL", ctypes.c_byte),
+            ("IDH", ctypes.c_ubyte),
+            ("IDL", ctypes.c_ubyte),
             ("Data", ctypes.c_byte * 8),
             ("Options", ctypes.c_byte),
             ("DataLength", ctypes.c_byte),

--- a/can/interfaces/ixxat/canlib.py
+++ b/can/interfaces/ixxat/canlib.py
@@ -565,7 +565,7 @@ class IXXATBus(BusABC):
                     constants.CAN_ACC_CODE_NONE,
                     constants.CAN_ACC_MASK_NONE,
                 )
-            for can_filter in can_filters:
+            for can_filter_name, can_filter in can_filters.items():
                 # Filters define what messages are accepted
                 code = int(can_filter["can_id"])
                 mask = int(can_filter["can_mask"])


### PR DESCRIPTION
Append 0x00 bytes until ecom data is 8 bytes - it is truncated before tx based on DLC
Implement filter option for ecom adapter